### PR TITLE
fix: calling made it working in ios

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -497,8 +497,8 @@ RCT_EXPORT_METHOD(sendString:(nonnull NSString *)message) {
 RCT_EXPORT_METHOD(disconnect) {
   [self clearCameraInstance];
   [self.room disconnect];
-  self.localAudioTrack = nil;
-  self.localVideoTrack = nil;
+  //self.localAudioTrack = nil;
+  //self.localVideoTrack = nil;
   self.lastVideoFrame = nil;
 }
 


### PR DESCRIPTION
I am refactoring/splitting the group call container into two part:
1 - Core call module
2 -Only UI displaying video feed and call controller

as part of this refactoring no need to make it nil assignment of local and video tracks, so commenting it now.
